### PR TITLE
Improve configuration for the dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 data/
+node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 data/
-node_modules/

--- a/.env.template
+++ b/.env.template
@@ -29,6 +29,9 @@ DB_TEST_PORT=27017
 DB_NAME=
 DB_TEST_NAME=
 
+# This is the exposed port of the mongo instance
+ME_CONFIG_MONGODB_PORT=27018
+
 # It has default value of "development" if not set here
 NODE_ENV=
 
@@ -81,4 +84,3 @@ REDIS_TEST_PORT=6379
 # Required only for dev environments
 MONGO_EXPRESS_EXTERNAL_PORT=8082
 REDIS_EXTERNAL_PORT=6378
-DB_EXTERNAL_PORT=27018

--- a/.env.template
+++ b/.env.template
@@ -64,8 +64,10 @@ BACKEND_SERVER_ADDRESS=127.0.0.1
 # Has a default time of 2h if not set
 EXPIRATION_TIME_FOR_WEB_TOKEN=
 
-# This has default value if not set here
-REDIS_PORT=
+# This is the default value we use in the 
+# config.js file, make sure this value matches that one
+# in the config.js file.
+REDIS_PORT=6379
 
 # Required. You can change this at your own expense if needed
 # These are persistent the docker volume directories to store

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,12 @@ services:
       DB_TEST_USER: ${DB_TEST_USER}
 
   mongo-express:
+  # TODO: Check if a contribution is needed here
+  # https://github.com/mongo-express/mongo-express-docker/pull/65/files
+  # In order to see if we can use the latest container image
+  # of mongo-express without the need of the mongo string url necessarily
+  # and also have the alternative to be able to use the port as a separate
+  # variable
     image: mongo-express:0.54
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: ${DB_ADMIN_USER}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,6 +25,7 @@ services:
   node:
     volumes:
       - ./:/home/node/app
+      - /home/node/app/node_modules
     ports:
       - ${PORT}:${PORT}
       - ${DEBUG_NODE_PORT}:${DEBUG_NODE_PORT}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,23 +4,24 @@ services:
 # The development configuration lives here
   mongo:
     ports:
-      - ${DB_EXTERNAL_PORT}:${DB_PORT}
+      - ${ME_CONFIG_MONGODB_PORT}:${DB_PORT}
     environment:
       DB_TEST_NAME: ${DB_TEST_NAME}
       DB_TEST_PASSWORD: ${DB_TEST_PASSWORD}
       DB_TEST_USER: ${DB_TEST_USER}
 
   mongo-express:
-    image: mongo-express
+    image: mongo-express:0.54
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: ${DB_ADMIN_USER}
       ME_CONFIG_MONGODB_ADMINPASSWORD: ${DB_ADMIN_PASSWORD}
+      ME_CONFIG_MONGODB_PORT: ${ME_CONFIG_MONGODB_PORT}
     depends_on:
       - mongo
     ports:
       - ${MONGO_EXPRESS_EXTERNAL_PORT}:8081
-    env_file:
-      - ./.env
+    expose:
+      - "${MONGO_EXPRESS_EXTERNAL_PORT}"
 
   node:
     volumes:


### PR DESCRIPTION
# Description

This is a Pull request that addresses changes on the dev setup that were not working properly after a couple of months.

## What changed

* [Added a default configuration for the REDIS_PORT variable](https://github.com/rivasvict/expenses-manager-api/commit/89b403e787f15f1a29a10a7afe06cca131248a07)
* [Removed the node_modules from the dockerignore](https://github.com/rivasvict/expenses-manager-api/commit/b21830105cafb24a7cee902db45e6bdd98399c1d)
* [Added an unbound volume to run node modules](https://github.com/rivasvict/expenses-manager-api/commit/d1bca070e46893a87f76d9e4ee0751e887d69ed0)
* [Resolve issue with the mongo-express container version](https://github.com/rivasvict/expenses-manager-api/commit/24b3f1bd6736c44a81c6481667fdb9de6c15d270)

For this last one, the solution was to move away from the latest version of mongo-express (to the 0.54) as it seems to suppress the use of the port and server name separately and it does it now in an unified URL instead. Which to me is not right. I believe we should have both options. Please check the follwoing link to see the [commit](https://github.com/mongo-express/mongo-express-docker/pull/65)

https://github.com/mongo-express/mongo-express-docker/pull/65 